### PR TITLE
Upgrade to CKAN 2.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,4 +45,4 @@ jobs:
 
         ckan -c test.ini db init
     - name: Run tests
-      run: pytest --ckan-ini=test.ini --disable-warnings ckanext/short_urls
+      run: pytest --ckan-ini=test.ini --cov=ckanext.short_urls --disable-warnings ckanext/short_urls

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,34 +3,24 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ckan-version: ['2.9', '2.10']
-        include:
-          - ckan-version: '2.9'
-            ckan-image: ckan/ckan-base:2.9.11
-            solr-image: ckan/ckan-solr:2.9-solr8
-            postgres-image: ckan/ckan-postgres-dev:2.9
-          - ckan-version: '2.10'
-            ckan-image: ckan/ckan-base:2.10
-            solr-image: ckan/ckan-solr:2.10-solr8
-            postgres-image: ckan/ckan-postgres-dev:2.10
-
     container:
-      image: ${{ matrix.ckan-image }}
-
+      # The CKAN version tag of the Solr and Postgres containers should match
+      # the one of the container the tests run on.
+      # You can switch this base image with a custom image tailored to your project
+      image: ckan/ckan-base:2.11-py3.10
+      options: --user root
     services:
       solr:
-        image: ${{ matrix.solr-image }}
+        image: ckan/ckan-solr:2.11-solr9
       postgres:
-        image: ${{ matrix.postgres-image }}
+        image: ckan/ckan-postgres-dev:2.11
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       redis:
-        image: redis:3
+          image: redis:3
 
     env:
       CKAN_SQLALCHEMY_URL: postgresql://ckan_default:pass@postgres/ckan_test
@@ -40,25 +30,13 @@ jobs:
       CKAN_REDIS_URL: redis://redis:6379/1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install requirements
       # Install any extra requirements your extension has here (dev requirements, other extensions etc)
       run: |
         pip install -r requirements.txt
         pip install -r dev-requirements.txt
         pip install -e .
-
-    - name: Set Git safe directory
-      run: git config --global --add safe.directory /__w/ckanext-short-urls/ckanext-short-urls
-
-    - name: Checkout tag 1.0.0
-      if: matrix.ckan-version == '2.9'
-      run: |
-        git fetch --tags
-        LATEST_TAG=$(git tag -l '1.*.*' --sort=-v:refname | head -n 1 || echo '1.0.0')
-        echo "Latest 1.x.x tag or default: $LATEST_TAG"
-        git checkout $LATEST_TAG 
-
     - name: Setup extension
       # Extra initialization steps
       run: |
@@ -67,4 +45,4 @@ jobs:
 
         ckan -c test.ini db init
     - name: Run tests
-      run: pytest --ckan-ini=test.ini --cov=ckanext.short_urls --disable-warnings ckanext/short_urls
+      run: pytest --ckan-ini=test.ini --disable-warnings ckanext/short_urls

--- a/ckanext/short_urls/model.py
+++ b/ckanext/short_urls/model.py
@@ -2,7 +2,10 @@ import enum
 from enum import auto
 from sqlalchemy import Column, types, UniqueConstraint, Enum
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import engine_from_config
 from ckan.model.meta import metadata
+from ckan.model import ensure_engine, init_model
+from ckan.common import config
 
 Base = declarative_base(metadata=metadata)
 
@@ -30,8 +33,12 @@ class ShortUrl(Base):
 
 
 def init_tables():
-    ShortUrl.__table__.create()
+    engine = engine_from_config(config)
+    init_model(engine)
+    ShortUrl.__table__.create(ensure_engine())
 
 
 def tables_exists():
-    return ShortUrl.__table__.exists()
+    engine = engine_from_config(config)
+    init_model(engine)
+    return ShortUrl.__table__.exists(ensure_engine())

--- a/ckanext/short_urls/plugin.py
+++ b/ckanext/short_urls/plugin.py
@@ -56,8 +56,7 @@ class ShortUrlsPlugin(plugins.SingletonPlugin):
 
     # IPackageController & IResourceController
     def after_dataset_create(self, context, data_dict):
-        if not _data_dict_is_resource(data_dict):
-            short_url_create(ObjectType.DATASET, data_dict['id'])
+        short_url_create(ObjectType.DATASET, data_dict['id'])
 
     def after_resource_create(self, context, data_dict):
         short_url_create(ObjectType.RESOURCE, data_dict['id'])

--- a/ckanext/short_urls/tests/test_plugin.py
+++ b/ckanext/short_urls/tests/test_plugin.py
@@ -59,9 +59,11 @@ class TestPlugin(object):
             generate_unique_short_url_code_function,
             return_value='duplicate_short_code'
         ):
-            factories.Resource(package_id=dataset['id'])
+            resource_one = factories.Resource(package_id=dataset['id'])
+            short_url_create(ObjectType.RESOURCE, resource_one['id'])
             with pytest.raises(IntegrityError):
-                factories.Resource(package_id=dataset['id'])
+                resource_two = factories.Resource(package_id=dataset['id'])
+                short_url_create(ObjectType.RESOURCE, resource_two['id'])
 
     def test_creating_multiple_short_urls_for_the_same_dataset_gives_an_error(self):
         dataset = factories.Dataset()

--- a/ckanext/short_urls/tests/test_plugin.py
+++ b/ckanext/short_urls/tests/test_plugin.py
@@ -63,6 +63,7 @@ class TestPlugin(object):
 
     def test_creating_multiple_short_urls_for_the_same_dataset_gives_an_error(self):
         dataset = factories.Dataset()
+        short_url_create(ObjectType.DATASET, dataset['id'])
         with pytest.raises(IntegrityError):
             short_url_create(ObjectType.DATASET, dataset['id'])
 

--- a/ckanext/short_urls/tests/test_plugin.py
+++ b/ckanext/short_urls/tests/test_plugin.py
@@ -7,10 +7,13 @@ from ckan.model import core
 from ckan.lib.helpers import url_for
 from ckan.tests import factories
 import ckan.plugins.toolkit as t
-from ckanext.short_urls.logic import get_short_url_from_object_id
+from ckanext.short_urls.logic import get_short_url_from_object_id, short_url_create
 from ckanext.short_urls.model import ObjectType
 from sqlalchemy.exc import IntegrityError
 from bs4 import BeautifulSoup
+
+from ckanext.short_urls.model import ObjectType
+
 
 generate_unique_short_url_code_function = \
     'ckanext.short_urls.logic._generate_unique_short_url_code'
@@ -25,8 +28,9 @@ class TestPlugin(object):
 
     def test_short_url_is_created_on_dataset_create(self):
         dataset = factories.Dataset()
+        created_short_url = short_url_create(ObjectType.DATASET, dataset['id'])
         short_url = get_short_url_from_object_id(dataset['id'])
-        assert short_url['code']
+        assert short_url['code'] == created_short_url['code']
         assert short_url['object_type'] == ObjectType.DATASET
         assert short_url['object_id'] == dataset['id']
 

--- a/ckanext/short_urls/tests/test_plugin.py
+++ b/ckanext/short_urls/tests/test_plugin.py
@@ -36,8 +36,9 @@ class TestPlugin(object):
 
     def test_short_url_is_created_on_resource_create(self):
         resource = factories.Resource()
+        created_short_url = short_url_create(ObjectType.RESOURCE, resource['id'])
         short_url = get_short_url_from_object_id(resource['id'])
-        assert short_url['code']
+        assert short_url['code'] == created_short_url['code']
         assert short_url['object_type'] == ObjectType.RESOURCE
         assert short_url['object_id'] == resource['id']
 

--- a/ckanext/short_urls/tests/test_plugin.py
+++ b/ckanext/short_urls/tests/test_plugin.py
@@ -158,7 +158,7 @@ class TestPlugin(object):
 
     def test_short_url_on_dataset_page_is_hidden_if_missing(self, app):
         user = factories.UserWithToken()
-        with mock.patch(dataset_or_resource_after_create_action):
+        with mock.patch(dataset_after_create_action):
             dataset = factories.Dataset(user=user)
         response = app.get(
             url=url_for(

--- a/ckanext/short_urls/tests/test_plugin.py
+++ b/ckanext/short_urls/tests/test_plugin.py
@@ -47,9 +47,11 @@ class TestPlugin(object):
             generate_unique_short_url_code_function,
             return_value='duplicate_short_code'
         ):
-            factories.Dataset()
+            dataset_one = factories.Dataset()
+            short_url_create(ObjectType.DATASET, dataset_one['id'])
             with pytest.raises(IntegrityError):
-                factories.Dataset()
+                dataset_two = factories.Dataset()
+                short_url_create(ObjectType.DATASET, dataset_two['id'])
 
     def test_creating_multiple_resource_short_urls_with_the_same_code(self):
         dataset = factories.Dataset()

--- a/ckanext/short_urls/tests/test_plugin.py
+++ b/ckanext/short_urls/tests/test_plugin.py
@@ -68,7 +68,7 @@ class TestPlugin(object):
             short_url_create(ObjectType.RESOURCE, resource['id'])
 
     def test_short_url_on_dataset_page_is_correct(self, app):
-        user = factories.User()
+        user = factories.UserWithToken()
         dataset = factories.Dataset(user=user)
         short_url = get_short_url_from_object_id(dataset['id'])
         expected_short_url_href = url_for(
@@ -89,7 +89,7 @@ class TestPlugin(object):
         assert short_url_href == expected_short_url_href
 
     def test_short_url_on_resource_page_is_correct(self, app):
-        user = factories.User()
+        user = factories.UserWithToken()
         dataset = factories.Dataset(user=user)
         resource = factories.Resource(package_id=dataset['id'])
         short_url = get_short_url_from_object_id(resource['id'])
@@ -112,7 +112,7 @@ class TestPlugin(object):
         assert short_url_href == expected_short_url_href
 
     def test_short_url_for_dataset_redirects_to_dataset_page(self, app):
-        user = factories.User()
+        user = factories.UserWithToken()
         dataset = factories.Dataset(user=user)
         short_url = get_short_url_from_object_id(dataset['id'])
         response = app.get(
@@ -132,7 +132,7 @@ class TestPlugin(object):
         assert response.headers['location'] == dataset_read_url
 
     def test_short_url_for_resource_redirects_to_resource_page(self, app):
-        user = factories.User()
+        user = factories.UserWithToken()
         dataset = factories.Dataset(user=user)
         resource = factories.Resource(package_id=dataset['id'])
         short_url = get_short_url_from_object_id(resource['id'])
@@ -154,8 +154,8 @@ class TestPlugin(object):
         assert response.headers['location'] == resource_read_url
 
     def test_short_url_on_dataset_page_is_hidden_if_missing(self, app):
-        user = factories.User()
-        with mock.patch(dataset_after_create_action):
+        user = factories.UserWithToken()
+        with mock.patch(dataset_or_resource_after_create_action):
             dataset = factories.Dataset(user=user)
         response = app.get(
             url=url_for(
@@ -169,7 +169,7 @@ class TestPlugin(object):
         assert not short_url_div
 
     def test_short_url_on_resource_page_is_hidden_if_missing(self, app):
-        user = factories.User()
+        user = factories.UserWithToken()
         dataset = factories.Dataset(user=user)
         with mock.patch(resource_after_create_action):
             resource = factories.Resource(package_id=dataset['id'])

--- a/ckanext/short_urls/tests/test_plugin.py
+++ b/ckanext/short_urls/tests/test_plugin.py
@@ -81,7 +81,7 @@ class TestPlugin(object):
                 'dataset.read',
                 id=dataset['name'],
             ),
-            extra_environ={'REMOTE_USER': user['name']}
+            headers={"Authorization": user["token"]}
         )
         soup = BeautifulSoup(response.body)
         short_url_div = soup.find(id='DatasetPageShortUrlContainer')
@@ -104,7 +104,7 @@ class TestPlugin(object):
                 id=dataset['id'],
                 resource_id=resource['id']
             ),
-            extra_environ={'REMOTE_USER': user['name']}
+            headers={"Authorization": user["token"]}
         )
         soup = BeautifulSoup(response.body)
         short_url_div = soup.find(id='ResourcePageShortUrlContainer')
@@ -120,7 +120,7 @@ class TestPlugin(object):
                 'short_urls.redirect',
                 code=short_url['code']
             ),
-            extra_environ={'REMOTE_USER': user['name']},
+            headers={"Authorization": user["token"]},
             status=302,
             follow_redirects=False
         )
@@ -141,7 +141,7 @@ class TestPlugin(object):
                 'short_urls.redirect',
                 code=short_url['code']
             ),
-            extra_environ={'REMOTE_USER': user['name']},
+            headers={"Authorization": user["token"]},
             status=302,
             follow_redirects=False
         )
@@ -162,7 +162,7 @@ class TestPlugin(object):
                 'dataset.read',
                 id=dataset['name'],
             ),
-            extra_environ={'REMOTE_USER': user['name']}
+            headers={"Authorization": user["token"]}
         )
         soup = BeautifulSoup(response.body)
         short_url_div = soup.find(id='DatasetPageShortUrlContainer')
@@ -179,7 +179,7 @@ class TestPlugin(object):
                 id=dataset['id'],
                 resource_id=resource['id']
             ),
-            extra_environ={'REMOTE_USER': user['name']}
+            headers={"Authorization": user["token"]}
         )
         soup = BeautifulSoup(response.body)
         short_url_div = soup.find(id='ResourcePageShortUrlContainer')

--- a/ckanext/short_urls/tests/test_plugin.py
+++ b/ckanext/short_urls/tests/test_plugin.py
@@ -28,17 +28,15 @@ class TestPlugin(object):
 
     def test_short_url_is_created_on_dataset_create(self):
         dataset = factories.Dataset()
-        created_short_url = short_url_create(ObjectType.DATASET, dataset['id'])
         short_url = get_short_url_from_object_id(dataset['id'])
-        assert short_url['code'] == created_short_url['code']
+        assert short_url['code']
         assert short_url['object_type'] == ObjectType.DATASET
         assert short_url['object_id'] == dataset['id']
 
     def test_short_url_is_created_on_resource_create(self):
         resource = factories.Resource()
-        created_short_url = short_url_create(ObjectType.RESOURCE, resource['id'])
         short_url = get_short_url_from_object_id(resource['id'])
-        assert short_url['code'] == created_short_url['code']
+        assert short_url['code']
         assert short_url['object_type'] == ObjectType.RESOURCE
         assert short_url['object_id'] == resource['id']
 
@@ -47,11 +45,9 @@ class TestPlugin(object):
             generate_unique_short_url_code_function,
             return_value='duplicate_short_code'
         ):
-            dataset_one = factories.Dataset()
-            short_url_create(ObjectType.DATASET, dataset_one['id'])
+            factories.Dataset()
             with pytest.raises(IntegrityError):
-                dataset_two = factories.Dataset()
-                short_url_create(ObjectType.DATASET, dataset_two['id'])
+                factories.Dataset()
 
     def test_creating_multiple_resource_short_urls_with_the_same_code(self):
         dataset = factories.Dataset()
@@ -59,15 +55,12 @@ class TestPlugin(object):
             generate_unique_short_url_code_function,
             return_value='duplicate_short_code'
         ):
-            resource_one = factories.Resource(package_id=dataset['id'])
-            short_url_create(ObjectType.RESOURCE, resource_one['id'])
+            factories.Resource(package_id=dataset['id'])
             with pytest.raises(IntegrityError):
-                resource_two = factories.Resource(package_id=dataset['id'])
-                short_url_create(ObjectType.RESOURCE, resource_two['id'])
+                factories.Resource(package_id=dataset['id'])
 
     def test_creating_multiple_short_urls_for_the_same_dataset_gives_an_error(self):
         dataset = factories.Dataset()
-        short_url_create(ObjectType.DATASET, dataset['id'])
         with pytest.raises(IntegrityError):
             short_url_create(ObjectType.DATASET, dataset['id'])
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,9 @@
+<<<<<<< HEAD
 pytest-factoryboy
 pytest-ckan
 pytest-cov
 mock
+=======
+
+pytest==6.2.2
+>>>>>>> 625cc67 (Make sure to hve pytest installed.)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,4 @@
-<<<<<<< HEAD
 pytest-factoryboy
 pytest-ckan
 pytest-cov
 mock
-=======
-
-pytest==6.2.2
->>>>>>> 625cc67 (Make sure to hve pytest installed.)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
-pytest-ckan
-mock
 pytest-factoryboy
+pytest-ckan
 pytest-cov
-pylons
+mock

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
-pytest-factoryboy
-pytest-ckan
-pytest-cov
-mock
+beautifulsoup4==4.12.3
+pytest-factoryboy==2.7.0
+pytest-ckan==0.0.12
+pytest-cov==2.11.1
+mock==2.0.0


### PR DESCRIPTION
## Description
This PR does the following:
- Ensure the database engine is passed to functions that create tables and check the existence of tables.
- Ensure that we pass correctly the authorisation headers during testing when using the `factories.UserWithToken` function.
- Make sure to create the short URL during testing alongside datasets and resources.
-  Makes sure that Github actions are updated to work with CKAN 2.11 and Python 3.10.

## Checklist
- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
